### PR TITLE
Automated pipeline(for marbles) execution with optional pipeline return…

### DIFF
--- a/src/magnify/pipeline.py
+++ b/src/magnify/pipeline.py
@@ -12,7 +12,9 @@ import magnify.utils as utils
 
 
 class Pipeline:
-    def __init__(self, reader: str, config: dict[str, dict[str, str]]):
+    def __init__(self, 
+                reader: str, 
+                config: dict[str, dict[str, str]]):
         self.reader: Callable[[ArrayLike | str], xr.Dataset] = registry.readers.get(reader)()
         self.config = confection.Config(config)
         self.components: list[Callable[[xr.Dataset], xr.Dataset]] = []
@@ -22,12 +24,10 @@ class Pipeline:
         else:
             logger.log_level = logging.INFO
 
-    def __call__(
-        self,
-        data: ArrayLike | str,
-        times: Sequence[int] | None = None,
-        channels: Sequence[str] | None = None,
-    ) -> xr.Dataset | list[xr.Dataset]:
+    def __call__(self,
+                data: ArrayLike | str,
+                times: Sequence[int] | None = None,
+                channels: Sequence[str] | None = None) -> xr.Dataset | list[xr.Dataset]:
         inputs = self.reader(data=data, times=times, channels=channels)
         assays = []
         for assay in inputs:

--- a/src/magnify/registry.py
+++ b/src/magnify/registry.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 import functools
 import inspect
-from typing import Callable
+from typing import Callable, Sequence
 
 from numpy.typing import ArrayLike
 import catalogue
 import confection
+import xarray as xr
 
 from magnify.pipeline import Pipeline
 
@@ -85,7 +86,14 @@ def pc_chip(**kwargs):
     return pipe
 
 
-def mrbles(**kwargs):
+def mrbles(data: ArrayLike | str = None,
+            return_pipe = False,                 
+            times: Sequence[int] | None = None,
+            channels: Sequence[str] | None = None,
+            **kwargs) -> Pipeline | xr.Dataset | list[xr.Dataset]:
+    if not return_pipe and data is None:
+        raise ValueError("The 'data' parameter cannot be None when 'return_pipe' is False.")
+    
     pipe = Pipeline("read", config=kwargs)
     pipe.add_pipe("flatfield_correct")
     pipe.add_pipe("stitch")
@@ -93,7 +101,9 @@ def mrbles(**kwargs):
     pipe.add_pipe("identify_mrbles")
     pipe.add_pipe("drop")
 
-    return pipe
+    if return_pipe:
+        return pipe
+    return pipe(data=data, times=times, channels=channels)
 
 
 def beads(**kwargs):


### PR DESCRIPTION
Modified the **function signature** and definition of ```mrbles``` in **registry.py**. 

It now takes an extra parameter ```return_pipe=False``` and the parameters of the ```__call__``` method.  When ```return_pipe``` is ```False```, the pipeline is automatically executed

If this change is validated as safe, I will proceed to modify the other pipelines to include this functionality. :)