### PR TITLE
Updates stitcher to trim all edges evenly rather than right/bottom only.

### DIFF
--- a/src/magnify/stitch.py
+++ b/src/magnify/stitch.py
@@ -8,11 +8,20 @@ class Stitcher:
         self.overlap = overlap
 
     def __call__(self, assay: xr.Dataset) -> xr.Dataset:
-        tiles = assay.tile[
-            ...,
-            : assay.tile.shape[-2] - self.overlap,
-            : assay.tile.shape[-1] - self.overlap,
-        ]
+        # Only clip if overlap is non-zero
+        if self.overlap > 0:
+            clip = self.overlap//2
+            # Account for odd overlaps
+            remainder = self.overlap%2
+
+            # Adjust tiles
+            tiles = assay.tile[
+                ...,
+                clip:-clip+remainder,
+                clip:-clip+remainder,
+            ]
+        else:
+            tiles = assay.tile
 
         # Move the time and channel axes last so we can focus on joining images.
         tiles = tiles.transpose("tile_row", "tile_col", "tile_y", "tile_x", "channel", "time")

--- a/src/magnify/stitch.py
+++ b/src/magnify/stitch.py
@@ -8,20 +8,16 @@ class Stitcher:
         self.overlap = overlap
 
     def __call__(self, assay: xr.Dataset) -> xr.Dataset:
-        # Only clip if overlap is non-zero
-        if self.overlap > 0:
-            clip = self.overlap//2
-            # Account for odd overlaps
-            remainder = self.overlap%2
-
-            # Adjust tiles
-            tiles = assay.tile[
-                ...,
-                clip:-clip+remainder,
-                clip:-clip+remainder,
-            ]
-        else:
-            tiles = assay.tile
+        # Take half of overlap from each edge
+        clip = self.overlap // 2
+        # Account for odd overlaps
+        remainder = self.overlap % 2
+        # Adjust tiles
+        tiles = assay.tile[
+            ...,
+            clip : assay.tile.shape[-2] - clip + remainder,
+            clip : assay.tile.shape[-1] - clip + remainder,
+        ]
 
         # Move the time and channel axes last so we can focus on joining images.
         tiles = tiles.transpose("tile_row", "tile_col", "tile_y", "tile_x", "channel", "time")


### PR DESCRIPTION
The stitcher currently trims each tile by adjusting the size of the image (e.g., `tile.shape[-1] - overlap`) which only cuts off one side of each tile rather than trimming it symmetrically. When the image has some vignetting or other artifacts on the edges, these would get carried over to each tile rather than being trimmed evenly and interfere with the chamber images.

For example, residual darkness from the neutral density filter on Setup 7 (which annoyingly remains even when the filter is fully open) is retained at the top of each chamber here and effectively cuts many chambers in half across full rows:
<img width="400" alt="Screenshot 2025-05-30 at 4 57 26 PM" src="https://github.com/user-attachments/assets/121064c9-3059-49b9-b4f9-028a949101f7" />

Adjusting the trimming operation to trim each edge of the image symmetrically gives much better images:
<img width="400" alt="Screenshot 2025-06-02 at 11 31 17 AM" src="https://github.com/user-attachments/assets/1c7d8fb3-a9bd-4628-b53d-cb34d4d3756a" />

This PR implements this fix and handles `overlap` values that are 0 or odd.